### PR TITLE
Make the Node.js SDK work in a Service Worker

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,56 +65,6 @@ declare class Analytics {
   );
 
   /**
-   *
-   * @param {Object} queueOpts
-   * @param {String=} queueOpts.queueName
-   * @param {String=} queueOpts.prefix
-   * @param {Boolean=} queueOpts.isMultiProcessor
-   * @param {Object} queueOpts.redisOpts
-   * @param {Number=} queueOpts.redisOpts.port
-   * @param {String=} queueOpts.redisOpts.host
-   * @param {Number=} queueOpts.redisOpts.db
-   * @param {String=} queueOpts.redisOpts.password
-   * @param {Object=} queueOpts.jobOpts
-   * @param {Number} queueOpts.jobOpts.maxAttempts
-   * {
-   *    queueName: string = rudderEventsQueue,
-   *    prefix: string = rudder
-   *    isMultiProcessor: booloean = false
-   *    redisOpts: {
-   *      port?: number = 6379;
-   *      host?: string = localhost;
-   *      db?: number = 0;
-   *      password?: string;
-   *    },
-   *    jobOpts: {
-   *      maxAttempts: number = 10
-   *    }
-   * }
-   * @param {*} callback
-   *  All error paths from redis and queue will give exception, so they are non-retryable from SDK perspective
-   *  The queue may not function for unhandled promise rejections
-   *  this error callback is called when the SDK wants the user to retry
-   */
-  createPersistenceQueue(
-    queueOpts: {
-      queueName?: string;
-      prefix?: string;
-      isMultiProcessor?: boolean;
-      redisOpts: {
-        port?: number;
-        host?: string;
-        db?: number;
-        password?: string;
-      };
-      jobOpts?: {
-        maxAttempts?: number;
-      };
-    },
-    callback: apiCallback
-  ): void;
-
-  /**
    * Send an identify `message`.
    *
    * @param {Object} message

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 const assert = require("assert");
 const removeSlash = require("remove-trailing-slash");
 const looselyValidate = require("@segment/loosely-validate-event");
-const serialize = require("serialize-javascript");
 const axios = require("axios");
 const axiosRetry = require("axios-retry");
 const ms = require("ms");
@@ -10,7 +9,6 @@ const md5 = require("md5");
 const isString = require("lodash.isstring");
 const cloneDeep = require("lodash.clonedeep");
 const version = require("./package.json").version;
-
 const setImmediate = global.setImmediate || process.nextTick.bind(process);
 const noop = () => {};
 
@@ -35,11 +33,6 @@ class Analytics {
     assert(dataPlaneURL, "You must pass your data plane url.");
 
     this.queue = [];
-    this.pQueue = undefined;
-    this.pQueueInitialized = false;
-    this.pQueueOpts = undefined;
-    this.pJobOpts = {};
-    this.state = "idle"; // this variable is not being used anymore. Previously it is used to prevent concurrency, added at the time of persistance support is added.
     this.writeKey = writeKey;
     this.host = removeSlash(dataPlaneURL);
     this.timeout = options.timeout || false;
@@ -363,15 +356,10 @@ class Analytics {
       callback(err, data);
     };
 
-    // Don't set the user agent if we're not on a browser. The latest spec allows
-    // the User-Agent header (see https://fetch.spec.whatwg.org/#terminology-headers
-    // and https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/setRequestHeader),
-    // but browsers such as Chrome and Safari have not caught up.
-    const headers = {};
-    if (typeof window === "undefined") {
-      headers["user-agent"] = `analytics-node/${version}`;
-    }
-
+    const headers = {
+      "Content-Type": "application/json",
+    };
+    
     const req = {
       method: "POST",
       url: `${this.host}`,
@@ -380,69 +368,39 @@ class Analytics {
       },
       data,
       headers,
+      responseType: "text",
+      "axios-retry": {
+        retries: 3,
+        retryCondition: this._isErrorRetryable.bind(this),
+        retryDelay: axiosRetry.exponentialDelay,
+      }
     };
-
+    
     if (this.timeout) {
       req.timeout =
         typeof this.timeout === "string" ? ms(this.timeout) : this.timeout;
     }
 
-    if (this.pQueue && this.pQueueInitialized) {
-      const eventData = {
-        description: `node-${md5(JSON.stringify(req))}-${uuidv4()}`,
-        request: req,
-        callbacks,
-        attempts: 0,
-      };
-      // using serialize library as default JSON.stringify mangles with function/callback serialization
-      this.pQueue
-        .add({ eventData: serialize(eventData) })
-        .then((pushedJob) => {
-          this.logger.debug("pushed job to queue");
-          this.timer = setTimeout(this.flush.bind(this), this.flushInterval);
-          this.state = "idle";
-        })
-        .catch((error) => {
-          this.timer = setTimeout(this.flush.bind(this), this.flushInterval);
-          this.queue.unshift(items);
-          this.state = "idle";
-          this.logger.error(
-            "failed to push to redis queue, in-memory queue size: " +
-              this.queue.length
-          );
-          throw error;
-        });
-    } else if (!this.pQueue) {
-      axios({
-        ...req,
-        "axios-retry": {
-          retries: 3,
-          retryCondition: this._isErrorRetryable.bind(this),
-          retryDelay: axiosRetry.exponentialDelay,
-        },
+    axios(req)
+      .then((response) => {
+        this.timer = setTimeout(this.flush.bind(this), this.flushInterval);
+        this.state = "idle";
+        done();
       })
-        .then((response) => {
-          this.timer = setTimeout(this.flush.bind(this), this.flushInterval);
-          this.state = "idle";
-          done();
-        })
-        .catch((err) => {
-          this.logger.error(
-            "got error while attempting send for 3 times, dropping " +
-              items.length +
-              " events"
-          );
-          this.timer = setTimeout(this.flush.bind(this), this.flushInterval);
-          this.state = "idle";
-          if (err.response) {
-            const error = new Error(err.response.statusText);
-            return done(error);
-          }
-          done(err);
-        });
-    } else {
-      throw new Error("persistent queue not ready");
-    }
+      .catch((err) => {
+        this.logger.error(
+          "got error while attempting send for 3 times, dropping " +
+            items.length +
+            " events: \n" + err
+        );
+        this.timer = setTimeout(this.flush.bind(this), this.flushInterval);
+        this.state = "idle";
+        if (err.response) {
+          const error = new Error(err.response.statusText);
+          return done(error);
+        }
+        done(err);
+      });
   }
 
   _isErrorRetryable(error) {

--- a/package.json
+++ b/package.json
@@ -34,15 +34,13 @@
     "@segment/loosely-validate-event": "^2.0.0",
     "axios": "0.26.0",
     "axios-retry": "^3.2.4",
-    "bull": "^4.7.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.isstring": "^4.0.1",
     "md5": "^2.3.0",
     "ms": "^2.1.3",
     "remove-trailing-slash": "^0.1.1",
     "serialize-javascript": "^6.0.0",
-    "uuid": "^8.3.2",
-    "winston": "^3.6.0"
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "auto-changelog": "^2.4.0",


### PR DESCRIPTION
Fix the RudderStack Node.js SDK so it works in a service worker. This is necessary to run it in an MV3 Chrome extension.

We removed code (and dependencies) that don't work in the browser and made a few changes to the request to improve functionality.